### PR TITLE
Update methods that support filtering

### DIFF
--- a/lib/TestRail/API.pm
+++ b/lib/TestRail/API.pm
@@ -2937,14 +2937,9 @@ sub _convert_filters_to_string {
 
     $filters //= {};
 
-    my @valid_keys = qw{ is_completed limit offset created_after created_before filter refs section_id updated_after updated_before refs_filter defects_filter };
-    my @valid_arrayref_keys = qw{ created_by milestone_id priority_id template_id type_id updated_by suite_id status_id };
-
     my $filter_string = '';
     foreach my $filter (keys(%$filters)) {
-        confess("Invalid filter key '$filter' passed") unless grep {$_ eq $filter} (@valid_keys, @valid_arrayref_keys);
         if (ref $filters->{$filter} eq 'ARRAY') {
-            confess "$filter cannot be an ARRAYREF" if grep {$_ eq $filter} @valid_keys;
             $filter_string .= "&$filter=".join(',',@{$filters->{$filter}});
         } else {
             $filter_string .= "&$filter=".$filters->{$filter} if defined($filters->{$filter});

--- a/t/TestRail-API.t
+++ b/t/TestRail-API.t
@@ -128,12 +128,9 @@ my $case_filters = {
 };
 
 ok($tr->getCases($new_project->{'id'},$new_suite->{'id'},$case_filters),"Can get case listing");
+ok($tr->getCases($new_project->{'id'},$new_suite->{'id'},{'hokum' => 'bogus'}),"Passing bogus filter returns cases");
 is($tr->getCaseByName($new_project->{'id'}, $new_suite->{'id'},  $case_name, $case_filters)->{'title'},$case_name,"Can get case by name");
 is($tr->getCaseByID($new_case->{'id'})->{'id'},$new_case->{'id'},"Can get case by ID");
-
-#Negative case
-$case_filters->{'hokum'} = 'bogus';
-isnt(exception {$tr->getCases($new_project->{'id'},$new_suite->{'id'},$case_filters)},undef,"Passing bogus filter croaks");
 
 #Test RUN methods
 my $run_name = 'SEND T-1000 INFILTRATION UNITS BACK IN TIME';


### PR DESCRIPTION
Fix filtering in getPlans. The user provided filters were not
being applied to the initial paginated request.

Add the ability to pass filters to getRuns and getRunsPaginated.

https://www.gurock.com/testrail/docs/api/reference/runs#getruns